### PR TITLE
Handle remote URLs that don't end in ".git"

### DIFF
--- a/lua/repolink/api.lua
+++ b/lua/repolink/api.lua
@@ -98,8 +98,8 @@ local function collect_git_remote(send, name)
   end
 
   local url_patterns = {
-    "^git@([^:]+):([^/]+)/(.+)%.git$",
-    "^https?://([^/]+)/([^/]+)/(.+)%.git$",
+    "^git@([^:]+):([^/]+)/(.+)$",
+    "^https?://([^/]+)/([^/]+)/(.+)$",
   }
 
   if M.c.custom_url_parser then
@@ -114,14 +114,15 @@ local function collect_git_remote(send, name)
   end
 
   for _, pattern in pairs(url_patterns) do
-    local host, user, project = string.match(remote_url, pattern)
+    local host, user, project_dot_git = string.match(remote_url, pattern)
 
     if host then
+      local project = string.match(project_dot_git, "^(.+)(%.git)$")
       return send({
         host = host,
         host_data = {
           user = user,
-          project = project,
+          project = project or project_dot_git,
         },
       })
     end


### PR DESCRIPTION
I'm not sure if it's technically allowed by the Git spec, but Github has no problem handling pushes to `https://github.com/my-user/my-repo`.

I was getting `Cannot parse remote URL` on a repo with a Github origin that didn't end in `.git`. After some investigation, I realized that Repolink will only match URLs that end in `.git`, even though it doesn't seem to be necessary for the rest of the plugin to function.

I considered just adding these patterns to `api.lua:100`, but that wouldn't have properly set the `project` variable for projects ending in another dot-extension, e.g. https://github.com/9seconds/repolink.nvim

Lua doesn't support optional capture groups, so running the `project` through another `string.match` to strip off the `.git` extension seemed like the best solution.